### PR TITLE
Add conjugate gradient preconditioning and regularization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@ Classical SLSQP solves the QP subproblem by forming and factorising the (n+m)×(
 
 Total cost per QP solve: O(n·k·t), where t is the number of CG iterations (typically t << n).
 
+**Preconditioning**: The CG solver supports an optional preconditioner M ≈ B⁻¹. By default, the L-BFGS inverse Hessian (two-loop recursion, Algorithm 7.4 of Nocedal & Wright) is used as M. This dramatically reduces the number of CG iterations on ill-conditioned subproblems (e.g., when proximal stabilization inflates the condition number). For projected CG, the preconditioner is applied as z = P(M(P(r))) to keep the search direction in the constraint null space.
+
 ### Derivative Computation
 
 By default, the solver computes:

--- a/README.md
+++ b/README.md
@@ -311,6 +311,34 @@ solver = SLSQP(
 
 When `proximal_sigma=0` (the default), the solver uses the standard hard-constraint QP and no stabilization overhead is incurred.
 
+### Preconditioning the CG solver
+
+When the L-BFGS scaling $\gamma$ is small (common after a few iterations) and proximal stabilization adds a $(1/\sigma)\, A_{\text{eq}}^T A_{\text{eq}}$ term to the Hessian, the effective condition number of the QP subproblem can reach $O(10^5)$ or higher. Standard (unpreconditioned) CG requires $O(\sqrt{\kappa})$ iterations to converge — far exceeding the default CG budget of 50 iterations. The result is an inaccurate QP solution, which corrupts the search direction and causes the outer solver to stagnate.
+
+This implementation uses **preconditioned conjugate gradient (PCG)** with the L-BFGS inverse Hessian as preconditioner. The key insight is that the L-BFGS pairs $(s_i, y_i)$ already stored in the history buffer can be used to compute $H_k v = B_k^{-1} v$ via the **two-loop recursion** (Nocedal & Wright, Algorithm 7.4) in $O(kn)$ time — the same cost as the forward HVP.
+
+When the preconditioner $M = B^{-1}$ is used:
+
+- **Without proximal term**: $M B = I$, so PCG converges in 1 iteration (perfect preconditioning).
+- **With proximal term**: $M \widetilde{B} = I + (1/\sigma)\, H_k\, A_{\text{eq}}^T A_{\text{eq}}$, and the condition number depends only on the proximal contribution, not the raw Hessian — typically orders of magnitude better.
+
+For projected (constrained) CG, the preconditioner is applied as $z = P(M(P(r)))$, where $P$ is the null-space projector. The extra projection ensures the preconditioned direction stays in the feasible subspace (Nocedal & Wright, Chapter 16).
+
+Preconditioning is enabled by default (`use_preconditioner=True`). Robust SPD guards ensure that if the preconditioner produces a non-positive-definite result for any residual, CG silently falls back to unpreconditioned mode for that step.
+
+```python
+solver = SLSQP(
+    eq_constraint_fn=eq_constraint,
+    n_eq_constraints=1,
+    use_preconditioner=True,   # Default; set False to disable
+    adaptive_cg_tol=False,     # Default; set True for Eisenstat-Walker tolerance
+)
+```
+
+**Adaptive CG tolerance (Eisenstat-Walker).** When `adaptive_cg_tol=True`, the CG convergence tolerance is adapted based on the outer KKT residual: $\eta_k = \min(0.1,\, \max(\texttt{atol},\, \lVert \nabla_x L \rVert))$. This avoids over-solving early QPs (when the outer iterate is far from optimal) and tightens the tolerance as convergence proceeds (Eisenstat & Walker, *SIAM J. Sci. Comput.*, 17(1), 1996). This is off by default to preserve baseline convergence behavior.
+
+**Why not rational CG?** We evaluated the rational conjugate gradient method (Kindermann & Zellinger, arXiv:2306.03670, 2023), which alternates CG steps with Tikhonov regularization steps in a mixed rational Krylov space. It is designed for ill-posed inverse problems with compact operators, not finite-dimensional positive definite QPs. Each rational step requires an inner solve of $(B + \alpha I)^{-1} v$, the regularization parameters need spectrum knowledge, and adapting the method to null-space projection is non-trivial. Standard PCG is simpler, cheaper, and directly addresses the ill-conditioning source.
+
 ### Outer-loop stagnation detection
 
 Even with anti-cycling in the QP, the outer SLSQP loop can fail to make progress — for example, when the problem is infeasible, highly degenerate, or the QP solution is of poor quality. The solver detects this by tracking the **L1 merit function** across iterations:

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -317,6 +317,34 @@ solver = SLSQP(
 
 When `proximal_sigma=0` (the default), the solver uses the standard hard-constraint QP and no stabilization overhead is incurred.
 
+### Preconditioning the CG solver
+
+When the L-BFGS scaling $\gamma$ is small (common after a few iterations) and proximal stabilization adds a $(1/\sigma)\, A_{\text{eq}}^T A_{\text{eq}}$ term to the Hessian, the effective condition number of the QP subproblem can reach $O(10^5)$ or higher. Standard (unpreconditioned) CG requires $O(\sqrt{\kappa})$ iterations to converge — far exceeding the default CG budget of 50 iterations. The result is an inaccurate QP solution, which corrupts the search direction and causes the outer solver to stagnate.
+
+This implementation uses **preconditioned conjugate gradient (PCG)** with the L-BFGS inverse Hessian as preconditioner. The key insight is that the L-BFGS pairs $(s_i, y_i)$ already stored in the history buffer can be used to compute $H_k v = B_k^{-1} v$ via the **two-loop recursion** (Nocedal & Wright, Algorithm 7.4) in $O(kn)$ time — the same cost as the forward HVP.
+
+When the preconditioner $M = B^{-1}$ is used:
+
+- **Without proximal term**: $M B = I$, so PCG converges in 1 iteration (perfect preconditioning).
+- **With proximal term**: $M \widetilde{B} = I + (1/\sigma)\, H_k\, A_{\text{eq}}^T A_{\text{eq}}$, and the condition number depends only on the proximal contribution, not the raw Hessian — typically orders of magnitude better.
+
+For projected (constrained) CG, the preconditioner is applied as $z = P(M(P(r)))$, where $P$ is the null-space projector. The extra projection ensures the preconditioned direction stays in the feasible subspace (Nocedal & Wright, Chapter 16).
+
+Preconditioning is enabled by default (`use_preconditioner=True`). Robust SPD guards ensure that if the preconditioner produces a non-positive-definite result for any residual, CG silently falls back to unpreconditioned mode for that step.
+
+```python
+solver = SLSQP(
+    eq_constraint_fn=eq_constraint,
+    n_eq_constraints=1,
+    use_preconditioner=True,   # Default; set False to disable
+    adaptive_cg_tol=False,     # Default; set True for Eisenstat-Walker tolerance
+)
+```
+
+**Adaptive CG tolerance (Eisenstat-Walker).** When `adaptive_cg_tol=True`, the CG convergence tolerance is adapted based on the outer KKT residual: $\eta_k = \min(0.1,\, \max(\texttt{atol},\, \lVert \nabla_x L \rVert))$. This avoids over-solving early QPs (when the outer iterate is far from optimal) and tightens the tolerance as convergence proceeds (Eisenstat & Walker, *SIAM J. Sci. Comput.*, 17(1), 1996). This is off by default to preserve baseline convergence behavior.
+
+**Why not rational CG?** We evaluated the rational conjugate gradient method (Kindermann & Zellinger, arXiv:2306.03670, 2023), which alternates CG steps with Tikhonov regularization steps in a mixed rational Krylov space. It is designed for ill-posed inverse problems with compact operators, not finite-dimensional positive definite QPs. Each rational step requires an inner solve of $(B + \alpha I)^{-1} v$, the regularization parameters need spectrum knowledge, and adapting the method to null-space projection is non-trivial. Standard PCG is simpler, cheaper, and directly addresses the ill-conditioning source.
+
 ### Outer-loop stagnation detection
 
 Even with anti-cycling in the QP, the outer SLSQP loop can fail to make progress — for example, when the problem is infeasible, highly degenerate, or the QP solution is of poor quality. The solver detects this by tracking the **L1 merit function** across iterations:

--- a/slsqp_jax/__init__.py
+++ b/slsqp_jax/__init__.py
@@ -17,6 +17,7 @@ from slsqp_jax.hessian import (
     lbfgs_append,
     lbfgs_hvp,
     lbfgs_init,
+    lbfgs_inverse_hvp,
 )
 from slsqp_jax.merit import (
     LineSearchResult,
@@ -56,6 +57,7 @@ __all__ = [
     "LBFGSHistory",
     "lbfgs_init",
     "lbfgs_hvp",
+    "lbfgs_inverse_hvp",
     "lbfgs_append",
     # Merit function
     "LineSearchResult",

--- a/slsqp_jax/compat.py
+++ b/slsqp_jax/compat.py
@@ -715,7 +715,8 @@ def minimize_like_scipy(
 
         Any remaining keys are forwarded as ``**kwargs`` to the
         ``SLSQP`` constructor, so any ``SLSQP`` attribute can be
-        set here (e.g. ``proximal_sigma``, ``stagnation_tol``,
+        set here (e.g. ``proximal_sigma``, ``use_preconditioner``,
+        ``adaptive_cg_tol``, ``stagnation_tol``,
         ``stagnation_patience``).
     has_aux
         If ``True``, *fun* returns ``(value, aux)``.

--- a/slsqp_jax/hessian.py
+++ b/slsqp_jax/hessian.py
@@ -163,6 +163,89 @@ def lbfgs_hvp(
 
 
 @jaxtyped(typechecker=beartype)
+def lbfgs_inverse_hvp(
+    history: LBFGSHistory,
+    v: Vector,
+) -> Vector:
+    """Compute H @ v = B^{-1} @ v via the L-BFGS two-loop recursion.
+
+    Implements Nocedal & Wright Algorithm 7.4.  Since the L-BFGS Hessian
+    approximation is B_k with initial scaling B_0 = gamma * I, the
+    inverse initial scaling is H_0 = (1/gamma) * I.
+
+    Complexity: O(kn) where k is the number of stored pairs.
+
+    Args:
+        history: L-BFGS history buffer.
+        v: Vector to multiply by the inverse Hessian approximation.
+
+    Returns:
+        H @ v = B^{-1} @ v, the inverse Hessian-vector product.
+    """
+    k = history.s_history.shape[0]
+    gamma = history.gamma
+    count = history.count
+
+    start = (history.next_idx - count + k) % k
+    indices = (start + jnp.arange(k)) % k
+    S = history.s_history[indices]  # (k, n) chronological
+    Y = history.y_history[indices]  # (k, n) chronological
+
+    valid_mask = (jnp.arange(k) < count)[:, None]
+    S = S * valid_mask
+    Y = Y * valid_mask
+
+    # rho_i = 1 / (y_i^T s_i); skip pairs with non-positive curvature
+    sTy = jnp.sum(S * Y, axis=1)  # (k,)
+    pair_ok = (jnp.arange(k) < count) & (sTy > 1e-12)
+    rho = jnp.where(pair_ok, 1.0 / sTy, 0.0)
+
+    # Backward loop: q = v; for i = k-1,...,0: alpha_i = rho_i s_i^T q; q -= alpha_i y_i
+    alphas_init = jnp.zeros(k)
+
+    def backward_step(carry, idx):
+        q, alphas = carry
+        rev_idx = k - 1 - idx
+        s_i = S[rev_idx]
+        y_i = Y[rev_idx]
+        rho_i = rho[rev_idx]
+        is_valid = rev_idx < count
+        alpha_i = jnp.where(is_valid, rho_i * jnp.dot(s_i, q), 0.0)
+        q = q - alpha_i * y_i
+        alphas = alphas.at[rev_idx].set(alpha_i)
+        return (q, alphas), None
+
+    (q, alphas), _ = jax.lax.scan(backward_step, (v, alphas_init), jnp.arange(k))
+
+    # Apply initial inverse Hessian: r = H_0 q = (1/gamma) q
+    gamma_safe = jnp.maximum(gamma, 1e-30)
+    r = q / gamma_safe
+
+    # Forward loop: for i = 0,...,k-1: beta = rho_i y_i^T r; r += s_i (alpha_i - beta)
+    def forward_step(r, idx):
+        s_i = S[idx]
+        y_i = Y[idx]
+        rho_i = rho[idx]
+        alpha_i = alphas[idx]
+        is_valid = idx < count
+        beta = jnp.where(is_valid, rho_i * jnp.dot(y_i, r), 0.0)
+        r = r + s_i * (alpha_i - beta)
+        return r, None
+
+    r, _ = jax.lax.scan(forward_step, r, jnp.arange(k))
+
+    v_norm = jnp.linalg.norm(v)
+    r_norm = jnp.linalg.norm(r)
+
+    # Fall back to identity if the result is non-finite or unreasonably large.
+    # Use plain v (not v/gamma) so the fallback always has unit spectral radius.
+    is_bad = jnp.any(~jnp.isfinite(r)) | (r_norm > 1000.0 * jnp.maximum(v_norm, 1e-10))
+    r = jnp.where(is_bad, v, r)
+
+    return r
+
+
+@jaxtyped(typechecker=beartype)
 def lbfgs_append(
     history: LBFGSHistory,
     s: Vector,

--- a/slsqp_jax/qp_solver.py
+++ b/slsqp_jax/qp_solver.py
@@ -69,12 +69,16 @@ class QPResult(NamedTuple):
 
 
 class _CGState(NamedTuple):
-    """Internal state for the projected conjugate gradient solver."""
+    """Internal state for the (preconditioned) conjugate gradient solver.
+
+    When a preconditioner M is used, ``rz`` stores r^T z (where z = M r)
+    instead of r^T r, and ``p`` is built from z rather than r.
+    """
 
     d: Vector
     r: Vector
     p: Vector
-    r_norm_sq: Scalar
+    rz: Scalar  # r^T z (preconditioned) or r^T r (unpreconditioned)
     iteration: Int[Array, ""]
     converged: Bool[Array, ""]
 
@@ -83,17 +87,22 @@ def _solve_unconstrained_cg(
     hvp_fn: Callable[[Vector], Vector],
     g: Vector,
     max_cg_iter: int,
-    cg_tol: float,
+    cg_tol: Scalar | float,
+    precond_fn: Callable[[Vector], Vector] | None = None,
 ) -> Vector:
     """Solve the unconstrained QP: min (1/2) d^T B d + g^T d.
 
-    Uses conjugate gradient to solve B d = -g without forming B.
+    Uses (preconditioned) conjugate gradient to solve B d = -g without
+    forming B.  When *precond_fn* is provided, the standard PCG algorithm
+    is used: z = M r, beta = r_new^T z_new / r_old^T z_old, and p is
+    built from z (Nocedal & Wright, Algorithm 5.3).
 
     Args:
         hvp_fn: Hessian-vector product function v -> B @ v.
         g: Linear term (gradient).
         max_cg_iter: Maximum CG iterations.
         cg_tol: Convergence tolerance on residual norm.
+        precond_fn: Optional preconditioner v -> M @ v where M ~ B^{-1}.
 
     Returns:
         Solution vector d.
@@ -102,11 +111,22 @@ def _solve_unconstrained_cg(
     r0 = -g
     r0_norm_sq = jnp.dot(r0, r0)
 
+    if precond_fn is not None:
+        z0 = precond_fn(r0)
+        rz0_raw = jnp.dot(r0, z0)
+        # Fall back to identity if preconditioner is not SPD for this residual
+        z0 = jnp.where(rz0_raw > 0, z0, r0)
+        rz0 = jnp.where(rz0_raw > 0, rz0_raw, r0_norm_sq)
+        p0 = z0
+    else:
+        rz0 = r0_norm_sq
+        p0 = r0
+
     init_cg = _CGState(
         d=jnp.zeros(n),
         r=r0,
-        p=r0,
-        r_norm_sq=r0_norm_sq,
+        p=p0,
+        rz=rz0,
         iteration=jnp.array(0),
         converged=r0_norm_sq < cg_tol**2,
     )
@@ -116,32 +136,39 @@ def _solve_unconstrained_cg(
             Bp = hvp_fn(state.p)
             pBp = jnp.dot(state.p, Bp)
 
-            # Detect negative or near-zero curvature
             has_bad_curvature = pBp <= 1e-8
 
             alpha = jnp.where(
                 has_bad_curvature,
                 jnp.array(0.0),
-                state.r_norm_sq / pBp,
+                state.rz / jnp.maximum(pBp, 1e-30),
             )
 
             d_new = state.d + alpha * state.p
             r_new = state.r - alpha * Bp
             r_new_norm_sq = jnp.dot(r_new, r_new)
 
-            beta = r_new_norm_sq / jnp.maximum(state.r_norm_sq, 1e-30)
-            p_new = r_new + beta * state.p
+            if precond_fn is not None:
+                z_new_raw = precond_fn(r_new)
+                rz_raw = jnp.dot(r_new, z_new_raw)
+                z_new = jnp.where(rz_raw > 0, z_new_raw, r_new)
+                rz_new = jnp.where(rz_raw > 0, rz_raw, r_new_norm_sq)
+            else:
+                z_new = r_new
+                rz_new = r_new_norm_sq
+
+            beta = rz_new / jnp.maximum(state.rz, 1e-30)
+            p_new = z_new + beta * state.p
 
             converged = (r_new_norm_sq < cg_tol**2) | has_bad_curvature
 
-            # If bad curvature, keep current state
             return jax.lax.cond(
                 has_bad_curvature,
                 lambda: _CGState(
                     d=state.d,
                     r=state.r,
                     p=state.p,
-                    r_norm_sq=state.r_norm_sq,
+                    rz=state.rz,
                     iteration=state.iteration + 1,
                     converged=jnp.array(True),
                 ),
@@ -149,7 +176,7 @@ def _solve_unconstrained_cg(
                     d=d_new,
                     r=r_new,
                     p=p_new,
-                    r_norm_sq=r_new_norm_sq,
+                    rz=rz_new,
                     iteration=state.iteration + 1,
                     converged=converged,
                 ),
@@ -168,9 +195,10 @@ def _solve_projected_cg(
     b: Float[Array, " m"],
     active_mask: Bool[Array, " m"],
     max_cg_iter: int,
-    cg_tol: float,
+    cg_tol: Scalar | float,
+    precond_fn: Callable[[Vector], Vector] | None = None,
 ) -> tuple[Vector, Float[Array, " m"]]:
-    """Solve equality-constrained QP using projected conjugate gradient.
+    """Solve equality-constrained QP using projected (preconditioned) CG.
 
     Solves:
         minimize    (1/2) d^T B d + g^T d
@@ -186,9 +214,9 @@ def _solve_projected_cg(
     3. Runs CG on the reduced problem in the null space of A.
     4. Recovers Lagrange multipliers from the KKT conditions.
 
-    The projection involves a small m x m system (A A^T) which is
-    solved directly. Inactive constraint rows are zeroed and regularized
-    so that the system remains non-singular.
+    When *precond_fn* is provided, the projected PCG algorithm is used:
+    z = P(M(P(r))) where M is the preconditioner (Nocedal & Wright,
+    Chapter 16).  The extra projection ensures z stays in the null space.
 
     Complexity per CG iteration: O(kn) for HVP + O(mn) for projection,
     where k is L-BFGS memory and m is the number of constraints.
@@ -201,6 +229,7 @@ def _solve_projected_cg(
         active_mask: Boolean mask (m,) indicating which constraints are active.
         max_cg_iter: Maximum CG iterations.
         cg_tol: CG convergence tolerance.
+        precond_fn: Optional preconditioner v -> M @ v where M ~ B^{-1}.
 
     Returns:
         Tuple of (d, multipliers) where d is the solution and multipliers
@@ -209,38 +238,39 @@ def _solve_projected_cg(
     """
     m = A.shape[0]
 
-    # Mask inactive constraints: zero out their rows
     A_masked = jnp.where(active_mask[:, None], A, 0.0)
     b_masked = jnp.where(active_mask, b, 0.0)
 
-    # Build regularized A A^T (m x m, small)
-    # Active rows contribute normally; inactive rows get diagonal 1.0
-    # to keep the system non-singular (their multiplier will be 0).
     reg_diag = jnp.where(active_mask, 0.0, 1.0)
     AAt = A_masked @ A_masked.T + jnp.diag(reg_diag) + 1e-8 * jnp.eye(m)
 
     def solve_AAt(rhs: Float[Array, " m"]) -> Float[Array, " m"]:
-        """Solve AAt @ x = rhs using direct solve."""
         return jnp.linalg.solve(AAt, rhs)
 
-    # Particular solution satisfying A d_p = b (for active constraints)
     d_p = A_masked.T @ solve_AAt(b_masked)
 
-    # Projection onto null space of active constraints:
-    # P(v) = v - A^T (A A^T)^{-1} A v
     def project(v: Vector) -> Vector:
         return v - A_masked.T @ solve_AAt(A_masked @ v)
 
-    # Initial residual for CG in the null space
     Bd_p = hvp_fn(d_p)
     r0 = project(-(g + Bd_p))
     r0_norm_sq = jnp.dot(r0, r0)
 
+    if precond_fn is not None:
+        z0 = project(precond_fn(r0))
+        rz0_raw = jnp.dot(r0, z0)
+        z0 = jnp.where(rz0_raw > 0, z0, r0)
+        rz0 = jnp.where(rz0_raw > 0, rz0_raw, r0_norm_sq)
+        p0 = z0
+    else:
+        rz0 = r0_norm_sq
+        p0 = r0
+
     init_cg = _CGState(
         d=d_p,
         r=r0,
-        p=r0,
-        r_norm_sq=r0_norm_sq,
+        p=p0,
+        rz=rz0,
         iteration=jnp.array(0),
         converged=r0_norm_sq < cg_tol**2,
     )
@@ -251,34 +281,39 @@ def _solve_projected_cg(
             PBp = project(Bp)
             pPBp = jnp.dot(state.p, PBp)
 
-            # Detect negative or near-zero curvature - stop CG and keep current d
             has_bad_curvature = pPBp <= 1e-8
 
-            # Only proceed if curvature is positive
             alpha = jnp.where(
                 has_bad_curvature,
                 jnp.array(0.0),
-                state.r_norm_sq / pPBp,
+                state.rz / jnp.maximum(pPBp, 1e-30),
             )
 
             d_new = state.d + alpha * state.p
             r_new = state.r - alpha * PBp
             r_new_norm_sq = jnp.dot(r_new, r_new)
 
-            beta = r_new_norm_sq / jnp.maximum(state.r_norm_sq, 1e-30)
-            p_new = r_new + beta * state.p
+            if precond_fn is not None:
+                z_new_raw = project(precond_fn(r_new))
+                rz_raw = jnp.dot(r_new, z_new_raw)
+                z_new = jnp.where(rz_raw > 0, z_new_raw, r_new)
+                rz_new = jnp.where(rz_raw > 0, rz_raw, r_new_norm_sq)
+            else:
+                z_new = r_new
+                rz_new = r_new_norm_sq
 
-            # Mark as converged if we have bad curvature (to stop iteration)
+            beta = rz_new / jnp.maximum(state.rz, 1e-30)
+            p_new = z_new + beta * state.p
+
             converged = (r_new_norm_sq < cg_tol**2) | has_bad_curvature
 
-            # If bad curvature, keep the previous state
             return jax.lax.cond(
                 has_bad_curvature,
                 lambda: _CGState(
                     d=state.d,
                     r=state.r,
                     p=state.p,
-                    r_norm_sq=state.r_norm_sq,
+                    rz=state.rz,
                     iteration=state.iteration + 1,
                     converged=jnp.array(True),
                 ),
@@ -286,7 +321,7 @@ def _solve_projected_cg(
                     d=d_new,
                     r=r_new,
                     p=p_new,
-                    r_norm_sq=r_new_norm_sq,
+                    rz=rz_new,
                     iteration=state.iteration + 1,
                     converged=converged,
                 ),
@@ -296,12 +331,9 @@ def _solve_projected_cg(
 
     final_cg = jax.lax.fori_loop(0, max_cg_iter, cg_step, init_cg)
 
-    # Recover multipliers from KKT stationarity:
-    # B d + g - A^T lambda = 0  =>  lambda = (A A^T)^{-1} A (B d + g)
     Bd = hvp_fn(final_cg.d)
     kkt_residual = A_masked @ (Bd + g)
     multipliers = solve_AAt(kkt_residual)
-    # Zero out multipliers for inactive constraints
     multipliers = jnp.where(active_mask, multipliers, 0.0)
 
     return final_cg.d, multipliers
@@ -318,12 +350,14 @@ def _solve_qp_proximal(
     m_ineq: int,
     max_iter: int,
     max_cg_iter: int,
-    tol: float,
+    tol: Scalar | float,
     expand_factor: float,
     initial_active_set: Bool[Array, " m_ineq"] | None,
     kkt_residual: Scalar | float,
     proximal_sigma: float,
     prev_multipliers_eq: Float[Array, " m_eq"] | None,
+    precond_fn: Callable[[Vector], Vector] | None = None,
+    cg_tol: Scalar | float | None = None,
 ) -> QPResult:
     """Solve the QP using the stabilized SQP (sSQP) formulation.
 
@@ -345,6 +379,7 @@ def _solve_qp_proximal(
     prev_mult_eq = (
         prev_multipliers_eq if prev_multipliers_eq is not None else jnp.zeros((m_eq,))
     )
+    inner_cg_tol: Scalar | float = cg_tol if cg_tol is not None else tol
 
     def stabilized_hvp(v: Vector) -> Vector:
         return hvp_fn(v) + inv_sigma * (A_eq.T @ (A_eq @ v))
@@ -356,7 +391,13 @@ def _solve_qp_proximal(
 
     # Sub-case: no inequality constraints — just unconstrained CG
     if m_ineq == 0:
-        d = _solve_unconstrained_cg(stabilized_hvp, g_mod, max_cg_iter, tol)
+        d = _solve_unconstrained_cg(
+            stabilized_hvp,
+            g_mod,
+            max_cg_iter,
+            inner_cg_tol,
+            precond_fn=precond_fn,
+        )
         return QPResult(
             d=d,
             multipliers_eq=_recover_mult_eq(d),
@@ -371,7 +412,13 @@ def _solve_qp_proximal(
     base_tol = tol + jnp.minimum(kkt_res, 1.0) * tol
 
     # Initial unconstrained solve (equalities absorbed into objective)
-    d_init = _solve_unconstrained_cg(stabilized_hvp, g_mod, max_cg_iter, tol)
+    d_init = _solve_unconstrained_cg(
+        stabilized_hvp,
+        g_mod,
+        max_cg_iter,
+        inner_cg_tol,
+        precond_fn=precond_fn,
+    )
 
     # Determine starting active set
     residuals_init = A_ineq @ d_init - b_ineq
@@ -406,7 +453,8 @@ def _solve_qp_proximal(
             b_ineq,
             state.active_set,
             max_cg_iter,
-            tol,
+            inner_cg_tol,
+            precond_fn=precond_fn,
         )
 
         mult_eq_new = _recover_mult_eq(d_new)
@@ -491,6 +539,8 @@ def solve_qp(
     kkt_residual: Scalar | float = 0.0,
     proximal_sigma: float = 0.0,
     prev_multipliers_eq: Float[Array, " m_eq"] | None = None,
+    precond_fn: Callable | None = None,
+    cg_tol: Scalar | float | None = None,
 ) -> QPResult:
     """Solve a QP with equality and inequality constraints.
 
@@ -558,6 +608,16 @@ def solve_qp(
         prev_multipliers_eq: Equality multipliers from the previous outer
             iteration, used as the proximal center when ``proximal_sigma > 0``.
             When ``None``, defaults to zeros.
+        precond_fn: Optional preconditioner function v -> M @ v where
+            M approximates H^{-1}.  When provided, the inner CG solver
+            uses preconditioned CG (PCG), which dramatically improves
+            convergence on ill-conditioned subproblems.  Typically
+            the L-BFGS inverse Hessian (two-loop recursion) is used.
+        cg_tol: Optional CG convergence tolerance that overrides ``tol``
+            for the inner CG solver only.  When ``None`` (default), the
+            CG solver uses ``tol``.  This allows the CG tolerance to be
+            adapted (e.g. Eisenstat-Walker) independently of the
+            feasibility tolerance used by the active-set method.
 
     Returns:
         QPResult containing the solution, multipliers, active set, and
@@ -567,9 +627,14 @@ def solve_qp(
     m_ineq = A_ineq.shape[0]
     m_total = m_eq + m_ineq
 
+    # Resolve CG tolerance: use cg_tol if provided, else fall back to tol.
+    inner_cg_tol: Scalar | float = cg_tol if cg_tol is not None else tol
+
     # Case 1: No constraints at all
     if m_total == 0:
-        d = _solve_unconstrained_cg(hvp_fn, g, max_cg_iter, tol)
+        d = _solve_unconstrained_cg(
+            hvp_fn, g, max_cg_iter, inner_cg_tol, precond_fn=precond_fn
+        )
         return QPResult(
             d=d,
             multipliers_eq=jnp.zeros((0,)),
@@ -580,7 +645,6 @@ def solve_qp(
         )
 
     # ---- Proximal stabilized path (sSQP) ----
-    # Absorb equality constraints into the objective when proximal_sigma > 0.
     if proximal_sigma > 0 and m_eq > 0:
         return _solve_qp_proximal(
             hvp_fn=hvp_fn,
@@ -599,6 +663,8 @@ def solve_qp(
             kkt_residual=kkt_residual,
             proximal_sigma=proximal_sigma,
             prev_multipliers_eq=prev_multipliers_eq,
+            precond_fn=precond_fn,
+            cg_tol=inner_cg_tol,
         )
 
     # ---- Standard path ----
@@ -607,7 +673,14 @@ def solve_qp(
     if m_ineq == 0:
         active_mask = jnp.ones(m_eq, dtype=bool)
         d, mult_eq = _solve_projected_cg(
-            hvp_fn, g, A_eq, b_eq, active_mask, max_cg_iter, tol
+            hvp_fn,
+            g,
+            A_eq,
+            b_eq,
+            active_mask,
+            max_cg_iter,
+            inner_cg_tol,
+            precond_fn=precond_fn,
         )
         return QPResult(
             d=d,
@@ -619,21 +692,24 @@ def solve_qp(
         )
 
     # Case 3: Has inequality constraints -> active-set method
-    # Build combined constraint matrix: [A_eq; A_ineq]
     A_combined = jnp.concatenate([A_eq, A_ineq], axis=0)
     b_combined = jnp.concatenate([b_eq, b_ineq])
 
-    # Adaptive EXPAND: widen base tolerance proportionally to KKT residual.
-    # When kkt_residual is 0 (default), this reduces to the original tol.
     kkt_residual = jnp.asarray(kkt_residual, dtype=jnp.float64)
     base_tol = tol + jnp.minimum(kkt_residual, 1.0) * tol
 
-    # Step 1: Initial solve with equality constraints only
     eq_only_mask = jnp.concatenate(
         [jnp.ones(m_eq, dtype=bool), jnp.zeros(m_ineq, dtype=bool)]
     )
     d_init, mult_init = _solve_projected_cg(
-        hvp_fn, g, A_combined, b_combined, eq_only_mask, max_cg_iter, tol
+        hvp_fn,
+        g,
+        A_combined,
+        b_combined,
+        eq_only_mask,
+        max_cg_iter,
+        inner_cg_tol,
+        precond_fn=precond_fn,
     )
 
     # Determine starting active set: warm-start or cold-start
@@ -670,7 +746,14 @@ def solve_qp(
 
         # Solve with current active set using projected CG
         d_new, mult_all = _solve_projected_cg(
-            hvp_fn, g, A_combined, b_combined, combined_mask, max_cg_iter, tol
+            hvp_fn,
+            g,
+            A_combined,
+            b_combined,
+            combined_mask,
+            max_cg_iter,
+            inner_cg_tol,
+            precond_fn=precond_fn,
         )
 
         mult_eq_new = mult_all[:m_eq] if m_eq > 0 else jnp.zeros((0,))

--- a/slsqp_jax/solver.py
+++ b/slsqp_jax/solver.py
@@ -32,6 +32,7 @@ from slsqp_jax.hessian import (
     lbfgs_append,
     lbfgs_hvp,
     lbfgs_init,
+    lbfgs_inverse_hvp,
 )
 from slsqp_jax.merit import (
     backtracking_line_search,
@@ -237,6 +238,13 @@ class SLSQP(optx.AbstractMinimiser):
             ``1/proximal_sigma``, regularizing the dual solution and preventing
             QP infeasibility at degenerate vertices.  Recommended range:
             ``[1e-4, 1e-1]``.  Default 0.0 disables stabilization.
+        use_preconditioner: When True (default), the L-BFGS inverse Hessian
+            (two-loop recursion) is used as a preconditioner for the inner
+            CG solver, dramatically improving convergence on ill-conditioned
+            QP subproblems.
+        adaptive_cg_tol: When True, the CG convergence tolerance is adapted
+            based on the outer KKT residual (Eisenstat-Walker style).
+            Default False preserves baseline behavior.
 
     Example:
         >>> import jax.numpy as jnp
@@ -331,6 +339,20 @@ class SLSQP(optx.AbstractMinimiser):
     # values mean more relaxation.  Recommended range: [1e-4, 1e-1].
     # Default 0.0 disables stabilization (standard QP).
     proximal_sigma: float = 0.0
+
+    # Preconditioned CG: use L-BFGS inverse Hessian (two-loop recursion)
+    # as preconditioner for the inner CG solver.  Dramatically improves
+    # convergence on ill-conditioned QP subproblems, especially when
+    # proximal_sigma is active.  Default True; set False to disable.
+    use_preconditioner: bool = eqx.field(static=True, default=True)
+
+    # Adaptive CG tolerance (Eisenstat-Walker-inspired).  Instead of
+    # a fixed CG tolerance of atol, the tolerance is set to
+    # min(0.1, max(atol, ||grad_L||)) so early QPs are solved loosely
+    # and accuracy increases as the outer solver converges.  Default
+    # False preserves baseline behavior; enable for large-scale problems
+    # where early QP over-solving is wasteful.
+    adaptive_cg_tol: bool = eqx.field(static=True, default=False)
 
     # Stagnation detection parameters
     stagnation_tol: float = 1e-12
@@ -569,6 +591,25 @@ class SLSQP(optx.AbstractMinimiser):
             return lbfgs_hvp(lbfgs_history, v)
 
         return lbfgs_lagrangian_hvp
+
+    def _build_preconditioner(
+        self,
+        state: "SLSQPState",
+    ) -> Callable[[Vector], Vector] | None:
+        """Build the L-BFGS inverse Hessian preconditioner for PCG.
+
+        Returns a closure v -> H_k @ v = B_k^{-1} @ v using the two-loop
+        recursion (Nocedal & Wright, Algorithm 7.4).  When preconditioning
+        is disabled, returns ``None``.
+        """
+        if not self.use_preconditioner:
+            return None
+        lbfgs_history = state.lbfgs_history
+
+        def preconditioner(v: Vector) -> Vector:
+            return lbfgs_inverse_hvp(lbfgs_history, v)
+
+        return preconditioner
 
     def _build_exact_lagrangian_hvp(
         self,
@@ -1042,6 +1083,12 @@ class SLSQP(optx.AbstractMinimiser):
         tolerance scaling.  When ``proximal_sigma > 0``, the equality
         constraints are absorbed into the objective via sSQP.
 
+        When ``use_preconditioner`` is True, the L-BFGS inverse Hessian
+        is passed to the QP solver as a CG preconditioner.
+
+        When ``adaptive_cg_tol`` is True, the CG tolerance is adapted
+        based on the outer KKT residual (Eisenstat-Walker style).
+
         Args:
             state: Current solver state.
             hvp_fn: Hessian-vector product function for the Lagrangian.
@@ -1052,19 +1099,25 @@ class SLSQP(optx.AbstractMinimiser):
         """
         g = state.grad
 
-        # Linearized constraints (rearranged to standard form)
         A_eq = state.eq_jac
         b_eq = -state.eq_val
 
         A_ineq = state.ineq_jac
         b_ineq = -state.ineq_val
 
-        # KKT residual for adaptive EXPAND tolerance
         kkt_residual = jnp.linalg.norm(state.prev_grad_lagrangian)
 
-        # Warm-start: use the active set from the previous outer iteration.
-        # On the first iteration prev_active_set is all-False (cold start).
         initial_active_set = state.prev_active_set
+
+        precond_fn = self._build_preconditioner(state)
+
+        # Eisenstat-Walker adaptive CG tolerance: solve loosely far from
+        # optimum (fast), tightly near the solution (accurate).
+        # Kept separate from `tol` so feasibility checking stays tight.
+        if self.adaptive_cg_tol:
+            adaptive_tol = jnp.minimum(0.1, jnp.maximum(self.atol, kkt_residual))
+        else:
+            adaptive_tol = None
 
         qp_result = solve_qp(
             hvp_fn=hvp_fn,
@@ -1079,6 +1132,8 @@ class SLSQP(optx.AbstractMinimiser):
             kkt_residual=kkt_residual,
             proximal_sigma=self.proximal_sigma,
             prev_multipliers_eq=state.multipliers_eq,
+            precond_fn=precond_fn,
+            cg_tol=adaptive_tol,
         )
 
         return QPResult(

--- a/tests/test_qp_solver.py
+++ b/tests/test_qp_solver.py
@@ -889,5 +889,167 @@ class TestProximalStabilization:
         )
 
 
+class TestPreconditionedCG:
+    """Tests for preconditioned conjugate gradient in the QP solver."""
+
+    def test_pcg_matches_unpreconditioned_well_conditioned(self):
+        """On a well-conditioned Hessian, PCG and CG produce the same result."""
+        H = jnp.array([[3.0, 1.0], [1.0, 4.0]])
+        g = jnp.array([1.0, -2.0])
+        A_eq = jnp.zeros((0, 2))
+        b_eq = jnp.zeros(0)
+        A_ineq = jnp.zeros((0, 2))
+        b_ineq = jnp.zeros(0)
+
+        H_inv = jnp.linalg.inv(H)
+
+        result_no_precond = solve_qp(_make_hvp(H), g, A_eq, b_eq, A_ineq, b_ineq)
+        result_precond = solve_qp(
+            _make_hvp(H),
+            g,
+            A_eq,
+            b_eq,
+            A_ineq,
+            b_ineq,
+            precond_fn=lambda v: H_inv @ v,
+        )
+
+        np.testing.assert_allclose(result_precond.d, result_no_precond.d, atol=1e-10)
+
+    def test_pcg_converges_ill_conditioned(self):
+        """PCG converges on an ill-conditioned H where unpreconditioned CG struggles."""
+        n = 20
+        rng = np.random.RandomState(42)
+        Q, _ = np.linalg.qr(rng.randn(n, n))
+        eigenvalues = np.logspace(-3, 2, n)
+        H = jnp.array(Q @ np.diag(eigenvalues) @ Q.T)
+        g = jnp.array(rng.randn(n))
+        A_eq = jnp.zeros((0, n))
+        b_eq = jnp.zeros(0)
+        A_ineq = jnp.zeros((0, n))
+        b_ineq = jnp.zeros(0)
+
+        expected = -jnp.linalg.solve(H, g)
+
+        H_inv = jnp.linalg.inv(H)
+        result_precond = solve_qp(
+            _make_hvp(H),
+            g,
+            A_eq,
+            b_eq,
+            A_ineq,
+            b_ineq,
+            max_cg_iter=5,
+            precond_fn=lambda v: H_inv @ v,
+        )
+        np.testing.assert_allclose(result_precond.d, expected, atol=1e-6)
+
+        result_no_precond = solve_qp(
+            _make_hvp(H),
+            g,
+            A_eq,
+            b_eq,
+            A_ineq,
+            b_ineq,
+            max_cg_iter=5,
+        )
+        error_no_precond = float(jnp.linalg.norm(result_no_precond.d - expected))
+        error_precond = float(jnp.linalg.norm(result_precond.d - expected))
+        assert error_precond < error_no_precond * 0.01
+
+    def test_pcg_with_proximal_stabilization(self):
+        """PCG works with proximal stabilization (sSQP)."""
+        H = jnp.eye(3) * 0.001
+        g = jnp.array([1.0, -1.0, 0.5])
+        A_eq = jnp.array([[1.0, 1.0, 0.0], [0.0, 1.0, 1.0]])
+        b_eq = jnp.array([1.0, 0.5])
+        A_ineq = jnp.zeros((0, 3))
+        b_ineq = jnp.zeros(0)
+
+        H_inv = jnp.linalg.inv(H)
+
+        result = solve_qp(
+            _make_hvp(H),
+            g,
+            A_eq,
+            b_eq,
+            A_ineq,
+            b_ineq,
+            proximal_sigma=0.01,
+            precond_fn=lambda v: H_inv @ v,
+        )
+        residual = A_eq @ result.d - b_eq
+        np.testing.assert_allclose(residual, 0.0, atol=0.1)
+
+    def test_pcg_projected_equality_constrained(self):
+        """PCG with equality constraints in projected null space."""
+        H = jnp.array([[10.0, 0.0], [0.0, 0.1]])
+        g = jnp.array([1.0, 1.0])
+        A_eq = jnp.array([[1.0, 1.0]])
+        b_eq = jnp.array([0.5])
+        A_ineq = jnp.zeros((0, 2))
+        b_ineq = jnp.zeros(0)
+
+        H_inv = jnp.linalg.inv(H)
+
+        result = solve_qp(
+            _make_hvp(H),
+            g,
+            A_eq,
+            b_eq,
+            A_ineq,
+            b_ineq,
+            precond_fn=lambda v: H_inv @ v,
+        )
+        np.testing.assert_allclose(A_eq @ result.d, b_eq, atol=1e-6)
+
+    def test_pcg_identity_preconditioner(self):
+        """Identity preconditioner behaves like no preconditioning."""
+        H = jnp.array([[2.0, 0.5], [0.5, 3.0]])
+        g = jnp.array([1.0, -1.0])
+        A_eq = jnp.zeros((0, 2))
+        b_eq = jnp.zeros(0)
+        A_ineq = jnp.zeros((0, 2))
+        b_ineq = jnp.zeros(0)
+
+        result_none = solve_qp(_make_hvp(H), g, A_eq, b_eq, A_ineq, b_ineq)
+        result_identity = solve_qp(
+            _make_hvp(H),
+            g,
+            A_eq,
+            b_eq,
+            A_ineq,
+            b_ineq,
+            precond_fn=lambda v: v,
+        )
+        np.testing.assert_allclose(result_identity.d, result_none.d, atol=1e-10)
+
+    def test_pcg_with_active_set(self):
+        """Full QP with inequality constraints and preconditioner."""
+        n = 10
+        rng = np.random.RandomState(123)
+        Q, _ = np.linalg.qr(rng.randn(n, n))
+        eigenvalues = np.logspace(-2, 2, n)
+        H = jnp.array(Q @ np.diag(eigenvalues) @ Q.T)
+        g = jnp.array(rng.randn(n))
+        A_eq = jnp.zeros((0, n))
+        b_eq = jnp.zeros(0)
+        A_ineq = jnp.eye(n)
+        b_ineq = jnp.zeros(n)
+
+        H_inv = jnp.linalg.inv(H)
+
+        result = solve_qp(
+            _make_hvp(H),
+            g,
+            A_eq,
+            b_eq,
+            A_ineq,
+            b_ineq,
+            precond_fn=lambda v: H_inv @ v,
+        )
+        np.testing.assert_array_less(-1e-6, A_ineq @ result.d - b_ineq)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_slsqp.py
+++ b/tests/test_slsqp.py
@@ -1934,3 +1934,112 @@ class TestProximalStabilization:
 
         sol = do_solve(x0)
         np.testing.assert_allclose(sol.value[0] + sol.value[1], 1.0, atol=1e-3)
+
+
+class TestPreconditionedSolver:
+    """Integration tests for the L-BFGS preconditioned CG solver."""
+
+    def test_preconditioned_convergence(self):
+        """Preconditioned solver converges on a problem with equality constraints."""
+
+        def objective(x, args):
+            return jnp.sum(x**2), None
+
+        def eq_constraint(x, args):
+            return jnp.array([x[0] + x[1] - 1.0])
+
+        solver = SLSQP(
+            eq_constraint_fn=eq_constraint,
+            n_eq_constraints=1,
+            use_preconditioner=True,
+            rtol=1e-6,
+            atol=1e-6,
+        )
+        x0 = jnp.array([0.1, 0.9])
+        y, state = _run_solver(solver, objective, x0)
+        np.testing.assert_allclose(y[0] + y[1], 1.0, atol=1e-4)
+        np.testing.assert_allclose(y[0], 0.5, atol=0.05)
+
+    def test_preconditioner_disabled_regression(self):
+        """use_preconditioner=False matches behavior of unpreconditioned solver."""
+
+        def objective(x, args):
+            return jnp.sum(x**2), None
+
+        def ineq_constraint(x, args):
+            return jnp.array([x[0] - 0.5])
+
+        solver_on = SLSQP(
+            ineq_constraint_fn=ineq_constraint,
+            n_ineq_constraints=1,
+            use_preconditioner=True,
+            adaptive_cg_tol=False,
+            rtol=1e-6,
+            atol=1e-6,
+        )
+        solver_off = SLSQP(
+            ineq_constraint_fn=ineq_constraint,
+            n_ineq_constraints=1,
+            use_preconditioner=False,
+            adaptive_cg_tol=False,
+            rtol=1e-6,
+            atol=1e-6,
+        )
+        x0 = jnp.array([2.0, 2.0])
+        y_on, _ = _run_solver(solver_on, objective, x0)
+        y_off, _ = _run_solver(solver_off, objective, x0)
+
+        np.testing.assert_allclose(y_on, y_off, atol=0.05)
+
+    def test_adaptive_cg_tol(self):
+        """Adaptive CG tolerance does not break convergence."""
+
+        def objective(x, args):
+            return (x[0] - 1.0) ** 2 + (x[1] - 2.0) ** 2, None
+
+        def eq_constraint(x, args):
+            return jnp.array([x[0] + x[1] - 2.0])
+
+        solver = SLSQP(
+            eq_constraint_fn=eq_constraint,
+            n_eq_constraints=1,
+            adaptive_cg_tol=True,
+            rtol=1e-6,
+            atol=1e-6,
+        )
+        x0 = jnp.array([0.0, 0.0])
+        y, _ = _run_solver(solver, objective, x0)
+        np.testing.assert_allclose(y[0] + y[1], 2.0, atol=1e-4)
+
+    def test_jit_compatible(self):
+        """JIT compilation works with preconditioning enabled."""
+
+        def objective(x, args):
+            return jnp.sum(x**2), None
+
+        def eq_constraint(x, args):
+            return jnp.array([x[0] + x[1] - 1.0])
+
+        solver = SLSQP(
+            eq_constraint_fn=eq_constraint,
+            n_eq_constraints=1,
+            use_preconditioner=True,
+            adaptive_cg_tol=True,
+            rtol=1e-6,
+            atol=1e-6,
+        )
+        x0 = jnp.array([0.5, 0.5])
+
+        @jax.jit
+        def do_solve(x0):
+            return optx.minimise(
+                objective,
+                solver,
+                x0,
+                has_aux=True,
+                max_steps=50,
+                throw=False,
+            )
+
+        sol = do_solve(x0)
+        np.testing.assert_allclose(sol.value[0] + sol.value[1], 1.0, atol=1e-3)


### PR DESCRIPTION
This PR stems from problems where stabilized SQP absorbed the equality constraints into the optimisation target to avoid QP cycling, but the search direction had a bad condition number, leading to the CG line search step not to converge on the allocated number of steps. To help CG, I added two thigs:

1. CG preconditioning based on the dual of the Hessian that is stored via L-BFGS history.
2. CG regularization to handle ill conditioned problems. This idea was adapted from Gill, Murray & Saunders (2005) SNOPT paper.
